### PR TITLE
update:starting script changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nodejs-boilerplate",
   "version": "1.0.0",
   "description": "[![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)",
-  "main": "index.js",
+  "main": "src/start.js",
   "directories": {
     "doc": "docs",
     "test": "test"
@@ -10,7 +10,8 @@
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watch --verbose",
-    "start": "nodemon src/start.js"
+    "start": "node src/start.js",
+    "dev":"nodemon src/start.js"
   },
   "keywords": [],
   "author": "",

--- a/src/start.js
+++ b/src/start.js
@@ -1,13 +1,13 @@
 const { startWebServer } = require('./server');
 
 const start = async () => {
-  console.log('Hello World');
+  console.log(`Last Run: ${new Date().toLocaleString()}`);
   await startWebServer();
 };
 
 start()
   .then(() => {
-    console.log('Done');
+    console.log('✓ Server started successfully!');
   })
   .catch((error) => {
     console.error(error);


### PR DESCRIPTION
Summary:

- `npm run dev` now runs the starting script(start.js) with nodemon and `npm run start` or `npm start` runs the starting script with node.
- 'node .' now runs the main file from package.json (which is src/start.js)
-improved messages of starting script.